### PR TITLE
Add insepctor info to GridScope modifiers

### DIFF
--- a/grid/src/commonMain/kotlin/com/cheonjaeung/compose/grid/GridAlignmentModifier.kt
+++ b/grid/src/commonMain/kotlin/com/cheonjaeung/compose/grid/GridAlignmentModifier.kt
@@ -4,6 +4,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.node.ModifierNodeElement
 import androidx.compose.ui.node.ParentDataModifierNode
+import androidx.compose.ui.platform.InspectorInfo
 import androidx.compose.ui.unit.Density
 
 internal class GridAlignmentElement(val alignment: Alignment) : ModifierNodeElement<GridAlignmentNode>() {
@@ -13,6 +14,11 @@ internal class GridAlignmentElement(val alignment: Alignment) : ModifierNodeElem
 
     override fun update(node: GridAlignmentNode) {
         node.alignment = alignment
+    }
+
+    override fun InspectorInfo.inspectableProperties() {
+        name = "align"
+        value = alignment
     }
 
     override fun equals(other: Any?): Boolean {

--- a/grid/src/commonMain/kotlin/com/cheonjaeung/compose/grid/GridSpanModifier.kt
+++ b/grid/src/commonMain/kotlin/com/cheonjaeung/compose/grid/GridSpanModifier.kt
@@ -3,6 +3,7 @@ package com.cheonjaeung.compose.grid
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.node.ModifierNodeElement
 import androidx.compose.ui.node.ParentDataModifierNode
+import androidx.compose.ui.platform.InspectorInfo
 import androidx.compose.ui.unit.Density
 
 internal class GridSpanElement(
@@ -14,6 +15,11 @@ internal class GridSpanElement(
 
     override fun update(node: GridSpanNode) {
         node.span = span
+    }
+
+    override fun InspectorInfo.inspectableProperties() {
+        name = "span"
+        value = span
     }
 
     override fun equals(other: Any?): Boolean {


### PR DESCRIPTION
Add inspector info to `GridScope`'s modifiers.

<img width="841" alt="image" src="https://github.com/user-attachments/assets/fa93c95c-6890-43a3-9109-78f4f7baf21f" />
