### PR TITLE
Adopt latest publishToMavenCentral API

### DIFF
--- a/grid/build.gradle.kts
+++ b/grid/build.gradle.kts
@@ -1,4 +1,3 @@
-import com.vanniktech.maven.publish.SonatypeHost
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
@@ -70,7 +69,7 @@ android {
 }
 
 mavenPublishing {
-    publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL)
+    publishToMavenCentral()
     signAllPublications()
     coordinates("${project.group}", "grid", "${project.version}")
 


### PR DESCRIPTION
In maven-publish plugin 0.33.0, the `publishToMavenCentral(SonatypeHost)` is deprecated.
This PR change it to new API, `publishToMavenCentral()`.