### PR TITLE
Change BoxGrid span modifier to receive BoxGridItemSpanScope and returns BoxGridItemSpan

### DIFF
--- a/docs/span.md
+++ b/docs/span.md
@@ -3,8 +3,8 @@
 The `content` composable lambda of grid layout extends `BoxGridScope`.
 In the `BoxGridScope`, you can use `rowSpan` and `columnSpan` modifier to set span size of cell.
 
-The `rowSpan` and `columnSpan` modifiers take a lambda to calculate span.
-The lambda returns an integer value, the span size.
+The `span` modifiers take a lambda to calculate spans.
+The lambda returns a `BoxGridItemSpan` which represents row and column span size.
 Or you can just pass `null` instead of lambda to use default span size, which is 1.
 
 ```kotlin
@@ -12,10 +12,10 @@ BoxGrid(
     rows = SimpleGridCells.Fixed(3),
     columns = SimpleGridCells.Fixed(3)
 ) {
-    Item(modifier = Modifier.rowSpan { 2 })
+    Item(modifier = Modifier.span { BoxGridItemSpan(rowSpan = 2, columnSpan = 1) })
     Item(modifier = Modifier.column(2))
-    Item(modifier = Modifier.row(1).column(1).columnSpan { 2 })
-    Item(modifier = Modifier.row(2).columnSpan { 2 })
+    Item(modifier = Modifier.row(1).column(1).span { BoxGridItemSpan(rowSpan = 1, columnSpan = 2) })
+    Item(modifier = Modifier.row(2)span { BoxGridItemSpan(rowSpan = 1, columnSpan = 2) })
 }
 ```
 

--- a/grid/api/android/grid.api
+++ b/grid/api/android/grid.api
@@ -1,14 +1,43 @@
+public final class com/cheonjaeung/compose/grid/BoxGridItemSpan {
+	public static final field Companion Lcom/cheonjaeung/compose/grid/BoxGridItemSpan$Companion;
+	public static final synthetic fun box-impl (J)Lcom/cheonjaeung/compose/grid/BoxGridItemSpan;
+	public static final fun component1-impl (J)I
+	public static final fun component2-impl (J)I
+	public fun equals (Ljava/lang/Object;)Z
+	public static fun equals-impl (JLjava/lang/Object;)Z
+	public static final fun equals-impl0 (JJ)Z
+	public static final fun getColumnSpan-impl (J)I
+	public static final fun getRowSpan-impl (J)I
+	public fun hashCode ()I
+	public static fun hashCode-impl (J)I
+	public fun toString ()Ljava/lang/String;
+	public static fun toString-impl (J)Ljava/lang/String;
+	public final synthetic fun unbox-impl ()J
+}
+
+public final class com/cheonjaeung/compose/grid/BoxGridItemSpan$Companion {
+}
+
+public abstract interface class com/cheonjaeung/compose/grid/BoxGridItemSpanScope {
+	public abstract fun getMaxColumnSpan ()I
+	public abstract fun getMaxCurrentColumnSpan ()I
+	public abstract fun getMaxCurrentRowSpan ()I
+	public abstract fun getMaxRowSpan ()I
+}
+
 public abstract interface class com/cheonjaeung/compose/grid/BoxGridScope {
 	public abstract fun align (Landroidx/compose/ui/Modifier;Landroidx/compose/ui/Alignment;)Landroidx/compose/ui/Modifier;
 	public abstract fun column (Landroidx/compose/ui/Modifier;I)Landroidx/compose/ui/Modifier;
-	public abstract fun columnSpan (Landroidx/compose/ui/Modifier;Lkotlin/jvm/functions/Function1;)Landroidx/compose/ui/Modifier;
 	public abstract fun row (Landroidx/compose/ui/Modifier;I)Landroidx/compose/ui/Modifier;
-	public abstract fun rowSpan (Landroidx/compose/ui/Modifier;Lkotlin/jvm/functions/Function1;)Landroidx/compose/ui/Modifier;
+	public abstract fun span (Landroidx/compose/ui/Modifier;Lkotlin/jvm/functions/Function1;)Landroidx/compose/ui/Modifier;
 }
 
 public final class com/cheonjaeung/compose/grid/BoxGridScope$DefaultImpls {
-	public static synthetic fun columnSpan$default (Lcom/cheonjaeung/compose/grid/BoxGridScope;Landroidx/compose/ui/Modifier;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Landroidx/compose/ui/Modifier;
-	public static synthetic fun rowSpan$default (Lcom/cheonjaeung/compose/grid/BoxGridScope;Landroidx/compose/ui/Modifier;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Landroidx/compose/ui/Modifier;
+	public static synthetic fun span$default (Lcom/cheonjaeung/compose/grid/BoxGridScope;Landroidx/compose/ui/Modifier;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Landroidx/compose/ui/Modifier;
+}
+
+public final class com/cheonjaeung/compose/grid/BoxGridSpanKt {
+	public static final fun BoxGridItemSpan (II)J
 }
 
 public abstract interface annotation class com/cheonjaeung/compose/grid/ExperimentalGridApi : java/lang/annotation/Annotation {

--- a/grid/api/jvm/grid.api
+++ b/grid/api/jvm/grid.api
@@ -1,14 +1,43 @@
+public final class com/cheonjaeung/compose/grid/BoxGridItemSpan {
+	public static final field Companion Lcom/cheonjaeung/compose/grid/BoxGridItemSpan$Companion;
+	public static final synthetic fun box-impl (J)Lcom/cheonjaeung/compose/grid/BoxGridItemSpan;
+	public static final fun component1-impl (J)I
+	public static final fun component2-impl (J)I
+	public fun equals (Ljava/lang/Object;)Z
+	public static fun equals-impl (JLjava/lang/Object;)Z
+	public static final fun equals-impl0 (JJ)Z
+	public static final fun getColumnSpan-impl (J)I
+	public static final fun getRowSpan-impl (J)I
+	public fun hashCode ()I
+	public static fun hashCode-impl (J)I
+	public fun toString ()Ljava/lang/String;
+	public static fun toString-impl (J)Ljava/lang/String;
+	public final synthetic fun unbox-impl ()J
+}
+
+public final class com/cheonjaeung/compose/grid/BoxGridItemSpan$Companion {
+}
+
+public abstract interface class com/cheonjaeung/compose/grid/BoxGridItemSpanScope {
+	public abstract fun getMaxColumnSpan ()I
+	public abstract fun getMaxCurrentColumnSpan ()I
+	public abstract fun getMaxCurrentRowSpan ()I
+	public abstract fun getMaxRowSpan ()I
+}
+
 public abstract interface class com/cheonjaeung/compose/grid/BoxGridScope {
 	public abstract fun align (Landroidx/compose/ui/Modifier;Landroidx/compose/ui/Alignment;)Landroidx/compose/ui/Modifier;
 	public abstract fun column (Landroidx/compose/ui/Modifier;I)Landroidx/compose/ui/Modifier;
-	public abstract fun columnSpan (Landroidx/compose/ui/Modifier;Lkotlin/jvm/functions/Function1;)Landroidx/compose/ui/Modifier;
 	public abstract fun row (Landroidx/compose/ui/Modifier;I)Landroidx/compose/ui/Modifier;
-	public abstract fun rowSpan (Landroidx/compose/ui/Modifier;Lkotlin/jvm/functions/Function1;)Landroidx/compose/ui/Modifier;
+	public abstract fun span (Landroidx/compose/ui/Modifier;Lkotlin/jvm/functions/Function1;)Landroidx/compose/ui/Modifier;
 }
 
 public final class com/cheonjaeung/compose/grid/BoxGridScope$DefaultImpls {
-	public static synthetic fun columnSpan$default (Lcom/cheonjaeung/compose/grid/BoxGridScope;Landroidx/compose/ui/Modifier;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Landroidx/compose/ui/Modifier;
-	public static synthetic fun rowSpan$default (Lcom/cheonjaeung/compose/grid/BoxGridScope;Landroidx/compose/ui/Modifier;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Landroidx/compose/ui/Modifier;
+	public static synthetic fun span$default (Lcom/cheonjaeung/compose/grid/BoxGridScope;Landroidx/compose/ui/Modifier;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Landroidx/compose/ui/Modifier;
+}
+
+public final class com/cheonjaeung/compose/grid/BoxGridSpanKt {
+	public static final fun BoxGridItemSpan (II)J
 }
 
 public abstract interface annotation class com/cheonjaeung/compose/grid/ExperimentalGridApi : java/lang/annotation/Annotation {

--- a/grid/src/commonMain/kotlin/com/cheonjaeung/compose/grid/BoxGridMeasurePolicy.kt
+++ b/grid/src/commonMain/kotlin/com/cheonjaeung/compose/grid/BoxGridMeasurePolicy.kt
@@ -112,12 +112,6 @@ private class BoxGridMeasureHelper(
             }
         }
 
-    private val BoxGridParentData?.rowSpanOrDefault: (GridItemSpanScope.() -> Int)
-        get() = this?.rowSpan ?: BoxGridParentData.DefaultSpan
-
-    private val BoxGridParentData?.columnSpanOrDefault: (GridItemSpanScope.() -> Int)
-        get() = this?.columnSpan ?: BoxGridParentData.DefaultSpan
-
     private val BoxGridParentData?.alignmentOrDefault: Alignment
         get() = this?.alignment ?: defaultAlignment
 
@@ -143,25 +137,20 @@ private class BoxGridMeasureHelper(
                 return@fastForEachIndexed
             }
 
-            val rowSpanScope = GridItemSpanScopeImpl(
-                maxCurrentLineSpan = rowCount - rowPosition,
-                maxLineSpan = rowCount
+            val spanScope = BoxGridItemSpanScopeImpl(
+                maxCurrentRowSpan = rowCount - rowPosition,
+                maxCurrentColumnSpan = columnCount - columnPosition,
+                maxRowSpan = rowCount,
+                maxColumnSpan = columnCount
             )
-            val columnSpanScope = GridItemSpanScopeImpl(
-                maxCurrentLineSpan = columnCount - columnPosition,
-                maxLineSpan = columnCount
-            )
-            val rowSpanFunction = parentDataArray[index].rowSpanOrDefault
-            val columnSpanFunction = parentDataArray[index].columnSpanOrDefault
-            val rowSpan = rowSpanFunction(rowSpanScope)
-            val columnSpan = columnSpanFunction(columnSpanScope)
+            val spanFunction = parentDataArray[index]?.span
+            val span = if (spanFunction != null) {
+                with(spanScope) { spanFunction() }
+            } else {
+                BoxGridItemSpan.Default
+            }
+            val (rowSpan, columnSpan) = span
 
-            require(rowSpan > 0) {
-                "rowSpan must be bigger than zero, $rowSpan is zero or negative"
-            }
-            require(columnSpan > 0) {
-                "columnSpan must be bigger than zero, $columnSpan is zero or negative"
-            }
             val remainingRowSpan = rowCount - rowPosition
             val remainingColumnSpan = columnCount - columnPosition
             if (rowSpan > remainingRowSpan || columnSpan > remainingColumnSpan) {

--- a/grid/src/commonMain/kotlin/com/cheonjaeung/compose/grid/BoxGridParentData.kt
+++ b/grid/src/commonMain/kotlin/com/cheonjaeung/compose/grid/BoxGridParentData.kt
@@ -5,8 +5,7 @@ import androidx.compose.ui.Alignment
 internal data class BoxGridParentData(
     var row: Int = UNSPECIFIED_ROW,
     var column: Int = UNSPECIFIED_COLUMN,
-    var rowSpan: GridItemSpanScope.() -> Int = DefaultSpan,
-    var columnSpan: GridItemSpanScope.() -> Int = DefaultSpan,
+    var span: (BoxGridItemSpanScope.() -> BoxGridItemSpan)? = null,
     var alignment: Alignment? = null
 ) {
     companion object {
@@ -14,6 +13,5 @@ internal data class BoxGridParentData(
         internal const val UNSPECIFIED_COLUMN: Int = -1
         internal const val DEFAULT_ROW: Int = 0
         internal const val DEFAULT_COLUMN: Int = 0
-        internal val DefaultSpan: GridItemSpanScope.() -> Int = { 1 }
     }
 }

--- a/grid/src/commonMain/kotlin/com/cheonjaeung/compose/grid/BoxGridScope.kt
+++ b/grid/src/commonMain/kotlin/com/cheonjaeung/compose/grid/BoxGridScope.kt
@@ -31,24 +31,14 @@ interface BoxGridScope {
     fun Modifier.column(column: Int): Modifier
 
     /**
-     * Sets the row span of the cell. The default span size is 1.
+     * Sets the row and column span of the cell. The default span size is 1.
      *
-     * @param span A span calculation lambda. If the result of [span] lambda is null, it means
-     * that this item uses default span size.
+     * @param span A span calculation lambda. If the result is null, it means that this item uses
+     * the default span size.
      */
     @Stable
     @ExperimentalGridApi
-    fun Modifier.rowSpan(span: ((GridItemSpanScope.() -> Int))? = null): Modifier
-
-    /**
-     * Sets the column span of the cell. The default span size is 1.
-     *
-     * @param span A span calculation lambda. If the result of [span] lambda is null, it means
-     * that this item uses default span size.
-     */
-    @Stable
-    @ExperimentalGridApi
-    fun Modifier.columnSpan(span: ((GridItemSpanScope.() -> Int))? = null): Modifier
+    fun Modifier.span(span: ((BoxGridItemSpanScope).() -> BoxGridItemSpan)? = null): Modifier
 
     /**
      * Aligns the item to specific [Alignment] within the cell.
@@ -86,24 +76,12 @@ internal object BoxGridScopeInstance : BoxGridScope {
         )
     }
 
-    override fun Modifier.rowSpan(span: (GridItemSpanScope.() -> Int)?): Modifier {
+    override fun Modifier.span(span: (BoxGridItemSpanScope.() -> BoxGridItemSpan)?): Modifier {
         return this.then(
             BoxGridSpanElement(
-                rowSpan = span ?: BoxGridParentData.DefaultSpan,
+                span = span,
                 inspectorInfo = debugInspectorInfo {
-                    name = "rowSpan"
-                    value = span
-                }
-            )
-        )
-    }
-
-    override fun Modifier.columnSpan(span: (GridItemSpanScope.() -> Int)?): Modifier {
-        return this.then(
-            BoxGridSpanElement(
-                columnSpan = span ?: BoxGridParentData.DefaultSpan,
-                inspectorInfo = debugInspectorInfo {
-                    name = "columnSpan"
+                    name = "span"
                     value = span
                 }
             )

--- a/grid/src/commonMain/kotlin/com/cheonjaeung/compose/grid/BoxGridSpan.kt
+++ b/grid/src/commonMain/kotlin/com/cheonjaeung/compose/grid/BoxGridSpan.kt
@@ -1,0 +1,76 @@
+package com.cheonjaeung.compose.grid
+
+import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.Stable
+import androidx.compose.ui.util.packInts
+import androidx.compose.ui.util.unpackInt1
+import androidx.compose.ui.util.unpackInt2
+import kotlin.jvm.JvmInline
+
+/**
+ * Create a [BoxGridItemSpan] from the given [row] and [column] span size parameter..
+ */
+fun BoxGridItemSpan(row: Int, column: Int): BoxGridItemSpan {
+    require(row > 0) { "span must be bigger than zero but rowSpan is $row" }
+    require(column > 0) { "span must be bigger than zero but columnSpan is $column" }
+    return BoxGridItemSpan(packedValue = packInts(row, column))
+}
+
+/**
+ * A value class which represents the spans of an item in a [BoxGrid].
+ */
+@Immutable
+@JvmInline
+value class BoxGridItemSpan internal constructor(private val packedValue: Long) {
+    @Stable
+    val rowSpan: Int
+        get() = unpackInt1(packedValue)
+
+    @Stable
+    val columnSpan: Int
+        get() = unpackInt2(packedValue)
+
+    @Stable
+    operator fun component1(): Int = rowSpan
+
+    @Stable
+    operator fun component2(): Int = columnSpan
+
+    companion object {
+        @Stable
+        internal val Default = BoxGridItemSpan(row = 1, column = 1)
+    }
+}
+
+/**
+ * A scope to calculate spans of items in the box grid layout.
+ */
+@GridItemScopeMarker
+sealed interface BoxGridItemSpanScope {
+    /**
+     * The maximum current row line span.
+     */
+    val maxCurrentRowSpan: Int
+
+    /**
+     * The maximum current column line span.
+     */
+    val maxCurrentColumnSpan: Int
+
+    /**
+     * The maximum row line span. It will be the number of the rows for box grid.
+     */
+    val maxRowSpan: Int
+
+    /**
+     * The maximum column line span. It will be the number of the columns for box grid.
+     */
+    val maxColumnSpan: Int
+}
+
+internal class BoxGridItemSpanScopeImpl(
+    override var maxCurrentRowSpan: Int,
+    override var maxCurrentColumnSpan: Int,
+    override var maxRowSpan: Int,
+    override var maxColumnSpan: Int
+) : BoxGridItemSpanScope

--- a/grid/src/commonMain/kotlin/com/cheonjaeung/compose/grid/BoxGridSpanModifier.kt
+++ b/grid/src/commonMain/kotlin/com/cheonjaeung/compose/grid/BoxGridSpanModifier.kt
@@ -7,17 +7,15 @@ import androidx.compose.ui.platform.InspectorInfo
 import androidx.compose.ui.unit.Density
 
 internal class BoxGridSpanElement(
-    val rowSpan: (GridItemSpanScope.() -> Int)? = null,
-    val columnSpan: (GridItemSpanScope.() -> Int)? = null,
+    val span: (BoxGridItemSpanScope.() -> BoxGridItemSpan)? = null,
     val inspectorInfo: InspectorInfo.() -> Unit
 ) : ModifierNodeElement<BoxGridSpanNode>() {
     override fun create(): BoxGridSpanNode {
-        return BoxGridSpanNode(rowSpan, columnSpan)
+        return BoxGridSpanNode(span)
     }
 
     override fun update(node: BoxGridSpanNode) {
-        node.rowSpan = rowSpan
-        node.columnSpan = columnSpan
+        node.span = span
     }
 
     override fun InspectorInfo.inspectableProperties() {
@@ -28,27 +26,21 @@ internal class BoxGridSpanElement(
         if (this === other) return true
         if (other == null) return false
         if (other !is BoxGridSpanElement) return false
-        return this.rowSpan == other.rowSpan && this.columnSpan == other.columnSpan
+        return this.span == other.span
     }
 
     override fun hashCode(): Int {
-        var hash = rowSpan.hashCode()
-        hash = 31 * hash + columnSpan.hashCode()
-        return hash
+        return span.hashCode()
     }
 }
 
 internal class BoxGridSpanNode(
-    var rowSpan: (GridItemSpanScope.() -> Int)?,
-    var columnSpan: (GridItemSpanScope.() -> Int)?
+    var span: (BoxGridItemSpanScope.() -> BoxGridItemSpan)?
 ) : Modifier.Node(), ParentDataModifierNode {
     override fun Density.modifyParentData(parentData: Any?): Any {
         val p = parentData as? BoxGridParentData ?: BoxGridParentData()
-        rowSpan?.let {
-            p.rowSpan = it
-        }
-        columnSpan?.let {
-            p.columnSpan = it
+        span?.let {
+            p.span = it
         }
         return p
     }

--- a/grid/src/test/java/com/cheonjaeung/compose/grid/BoxGridSpanTest.kt
+++ b/grid/src/test/java/com/cheonjaeung/compose/grid/BoxGridSpanTest.kt
@@ -66,7 +66,7 @@ class BoxGridSpanTest {
                     modifier = Modifier
                         .size(100.dp)
                         .background(Color.Blue)
-                        .rowSpan { 1 }
+                        .span { BoxGridItemSpan(row = 1, column = 1) }
                 )
                 Box(
                     modifier = Modifier
@@ -74,8 +74,7 @@ class BoxGridSpanTest {
                         .column(1)
                         .size(100.dp)
                         .background(Color.Green)
-                        .rowSpan { 1 }
-                        .columnSpan { 1 }
+                        .span { BoxGridItemSpan(row = 1, column = 1) }
                 )
                 Box(
                     modifier = Modifier
@@ -83,7 +82,7 @@ class BoxGridSpanTest {
                         .column(2)
                         .size(100.dp)
                         .background(Color.Yellow)
-                        .columnSpan { 1 }
+                        .span { BoxGridItemSpan(row = 1, column = 1) }
                 )
             }
         }
@@ -103,7 +102,7 @@ class BoxGridSpanTest {
                     modifier = Modifier
                         .size(100.dp)
                         .background(Color.Blue)
-                        .rowSpan { 2 }
+                        .span { BoxGridItemSpan(row = 2, column = 1) }
                 )
                 Box(
                     modifier = Modifier
@@ -111,8 +110,7 @@ class BoxGridSpanTest {
                         .column(1)
                         .size(100.dp)
                         .background(Color.Green)
-                        .rowSpan { 2 }
-                        .columnSpan { 2 }
+                        .span { BoxGridItemSpan(row = 2, column = 2) }
                 )
                 Box(
                     modifier = Modifier
@@ -120,7 +118,7 @@ class BoxGridSpanTest {
                         .column(2)
                         .size(100.dp)
                         .background(Color.Yellow)
-                        .columnSpan { 2 }
+                        .span { BoxGridItemSpan(row = 1, column = 2) }
                 )
             }
         }
@@ -140,7 +138,7 @@ class BoxGridSpanTest {
                     modifier = Modifier
                         .size(100.dp)
                         .background(Color.Blue)
-                        .rowSpan { 2 }
+                        .span { BoxGridItemSpan(row = 2, column = 1) }
                 )
                 Box(
                     modifier = Modifier
@@ -148,8 +146,7 @@ class BoxGridSpanTest {
                         .column(1)
                         .size(100.dp)
                         .background(Color.Green)
-                        .rowSpan { 5 }
-                        .columnSpan { 5 }
+                        .span { BoxGridItemSpan(row = maxRowSpan + 1, column = maxColumnSpan + 1) }
                 )
                 Box(
                     modifier = Modifier
@@ -157,7 +154,7 @@ class BoxGridSpanTest {
                         .column(2)
                         .size(100.dp)
                         .background(Color.Yellow)
-                        .columnSpan { 2 }
+                        .span { BoxGridItemSpan(row = 1, column = 2) }
                 )
             }
         }
@@ -177,7 +174,7 @@ class BoxGridSpanTest {
                     modifier = Modifier
                         .size(100.dp)
                         .background(Color.Blue)
-                        .rowSpan { maxLineSpan }
+                        .span { BoxGridItemSpan(row = maxRowSpan, column = 1) }
                 )
                 Box(
                     modifier = Modifier
@@ -218,7 +215,7 @@ class BoxGridSpanTest {
                         .column(1)
                         .size(100.dp)
                         .background(Color.Green)
-                        .rowSpan { maxCurrentLineSpan }
+                        .span { BoxGridItemSpan(row = maxCurrentRowSpan, column = 1) }
                 )
                 Box(
                     modifier = Modifier
@@ -226,7 +223,7 @@ class BoxGridSpanTest {
                         .column(2)
                         .size(100.dp)
                         .background(Color.Yellow)
-                        .columnSpan { maxCurrentLineSpan }
+                        .span { BoxGridItemSpan(row = 1, column = maxCurrentColumnSpan) }
                 )
             }
         }


### PR DESCRIPTION
Add `Modifier.span` for `BoxGrid`, `BoxGridItemSpanScope` and `BoxGridItemSpan`.

`BoxGridItemSpanScope` is a scope contains max line span and current max span for each row and column.
`BoxGridItemSpan` is a value class represents row/column span value.

BoxGrid's `Modifier.rowSpan` and `Modifier.columnSpan` is removed.