### PR TITLE
Add default parameter to BoxGridItemSpan

### DIFF
--- a/grid/api/android/grid.api
+++ b/grid/api/android/grid.api
@@ -1,5 +1,4 @@
 public final class com/cheonjaeung/compose/grid/BoxGridItemSpan {
-	public static final field Companion Lcom/cheonjaeung/compose/grid/BoxGridItemSpan$Companion;
 	public static final synthetic fun box-impl (J)Lcom/cheonjaeung/compose/grid/BoxGridItemSpan;
 	public static final fun component1-impl (J)I
 	public static final fun component2-impl (J)I
@@ -13,9 +12,6 @@ public final class com/cheonjaeung/compose/grid/BoxGridItemSpan {
 	public fun toString ()Ljava/lang/String;
 	public static fun toString-impl (J)Ljava/lang/String;
 	public final synthetic fun unbox-impl ()J
-}
-
-public final class com/cheonjaeung/compose/grid/BoxGridItemSpan$Companion {
 }
 
 public abstract interface class com/cheonjaeung/compose/grid/BoxGridItemSpanScope {
@@ -38,6 +34,7 @@ public final class com/cheonjaeung/compose/grid/BoxGridScope$DefaultImpls {
 
 public final class com/cheonjaeung/compose/grid/BoxGridSpanKt {
 	public static final fun BoxGridItemSpan (II)J
+	public static synthetic fun BoxGridItemSpan$default (IIILjava/lang/Object;)J
 }
 
 public abstract interface annotation class com/cheonjaeung/compose/grid/ExperimentalGridApi : java/lang/annotation/Annotation {

--- a/grid/api/jvm/grid.api
+++ b/grid/api/jvm/grid.api
@@ -1,5 +1,4 @@
 public final class com/cheonjaeung/compose/grid/BoxGridItemSpan {
-	public static final field Companion Lcom/cheonjaeung/compose/grid/BoxGridItemSpan$Companion;
 	public static final synthetic fun box-impl (J)Lcom/cheonjaeung/compose/grid/BoxGridItemSpan;
 	public static final fun component1-impl (J)I
 	public static final fun component2-impl (J)I
@@ -13,9 +12,6 @@ public final class com/cheonjaeung/compose/grid/BoxGridItemSpan {
 	public fun toString ()Ljava/lang/String;
 	public static fun toString-impl (J)Ljava/lang/String;
 	public final synthetic fun unbox-impl ()J
-}
-
-public final class com/cheonjaeung/compose/grid/BoxGridItemSpan$Companion {
 }
 
 public abstract interface class com/cheonjaeung/compose/grid/BoxGridItemSpanScope {
@@ -38,6 +34,7 @@ public final class com/cheonjaeung/compose/grid/BoxGridScope$DefaultImpls {
 
 public final class com/cheonjaeung/compose/grid/BoxGridSpanKt {
 	public static final fun BoxGridItemSpan (II)J
+	public static synthetic fun BoxGridItemSpan$default (IIILjava/lang/Object;)J
 }
 
 public abstract interface annotation class com/cheonjaeung/compose/grid/ExperimentalGridApi : java/lang/annotation/Annotation {

--- a/grid/src/commonMain/kotlin/com/cheonjaeung/compose/grid/BoxGridMeasurePolicy.kt
+++ b/grid/src/commonMain/kotlin/com/cheonjaeung/compose/grid/BoxGridMeasurePolicy.kt
@@ -147,7 +147,7 @@ private class BoxGridMeasureHelper(
             val span = if (spanFunction != null) {
                 with(spanScope) { spanFunction() }
             } else {
-                BoxGridItemSpan.Default
+                BoxGridItemSpan()
             }
             val (rowSpan, columnSpan) = span
 

--- a/grid/src/commonMain/kotlin/com/cheonjaeung/compose/grid/BoxGridSpan.kt
+++ b/grid/src/commonMain/kotlin/com/cheonjaeung/compose/grid/BoxGridSpan.kt
@@ -10,7 +10,7 @@ import kotlin.jvm.JvmInline
 /**
  * Create a [BoxGridItemSpan] from the given [row] and [column] span size parameter..
  */
-fun BoxGridItemSpan(row: Int, column: Int): BoxGridItemSpan {
+fun BoxGridItemSpan(row: Int = 1, column: Int = 1): BoxGridItemSpan {
     require(row > 0) { "span must be bigger than zero but rowSpan is $row" }
     require(column > 0) { "span must be bigger than zero but columnSpan is $column" }
     return BoxGridItemSpan(packedValue = packInts(row, column))
@@ -35,11 +35,6 @@ value class BoxGridItemSpan internal constructor(private val packedValue: Long) 
 
     @Stable
     operator fun component2(): Int = columnSpan
-
-    companion object {
-        @Stable
-        internal val Default = BoxGridItemSpan(row = 1, column = 1)
-    }
 }
 
 /**

--- a/grid/src/test/java/com/cheonjaeung/compose/grid/BoxGridSpanTest.kt
+++ b/grid/src/test/java/com/cheonjaeung/compose/grid/BoxGridSpanTest.kt
@@ -102,7 +102,7 @@ class BoxGridSpanTest {
                     modifier = Modifier
                         .size(100.dp)
                         .background(Color.Blue)
-                        .span { BoxGridItemSpan(row = 2, column = 1) }
+                        .span { BoxGridItemSpan(row = 2) }
                 )
                 Box(
                     modifier = Modifier
@@ -118,7 +118,7 @@ class BoxGridSpanTest {
                         .column(2)
                         .size(100.dp)
                         .background(Color.Yellow)
-                        .span { BoxGridItemSpan(row = 1, column = 2) }
+                        .span { BoxGridItemSpan(column = 2) }
                 )
             }
         }
@@ -138,7 +138,7 @@ class BoxGridSpanTest {
                     modifier = Modifier
                         .size(100.dp)
                         .background(Color.Blue)
-                        .span { BoxGridItemSpan(row = 2, column = 1) }
+                        .span { BoxGridItemSpan(row = 2) }
                 )
                 Box(
                     modifier = Modifier
@@ -154,7 +154,7 @@ class BoxGridSpanTest {
                         .column(2)
                         .size(100.dp)
                         .background(Color.Yellow)
-                        .span { BoxGridItemSpan(row = 1, column = 2) }
+                        .span { BoxGridItemSpan(column = 2) }
                 )
             }
         }
@@ -174,7 +174,7 @@ class BoxGridSpanTest {
                     modifier = Modifier
                         .size(100.dp)
                         .background(Color.Blue)
-                        .span { BoxGridItemSpan(row = maxRowSpan, column = 1) }
+                        .span { BoxGridItemSpan(row = maxRowSpan) }
                 )
                 Box(
                     modifier = Modifier
@@ -215,7 +215,7 @@ class BoxGridSpanTest {
                         .column(1)
                         .size(100.dp)
                         .background(Color.Green)
-                        .span { BoxGridItemSpan(row = maxCurrentRowSpan, column = 1) }
+                        .span { BoxGridItemSpan(row = maxCurrentRowSpan) }
                 )
                 Box(
                     modifier = Modifier
@@ -223,7 +223,7 @@ class BoxGridSpanTest {
                         .column(2)
                         .size(100.dp)
                         .background(Color.Yellow)
-                        .span { BoxGridItemSpan(row = 1, column = maxCurrentColumnSpan) }
+                        .span { BoxGridItemSpan(column = maxCurrentColumnSpan) }
                 )
             }
         }


### PR DESCRIPTION
Add default parameter to BoxGridItemSpan to use like `BoxGridItemSpan(row = 2)` or `BoxGridItemSpan(column = 3)`.