### PR TITLE
Upgrade Project Dependencies

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,33 +1,33 @@
 [versions]
-kotlin = "2.1.0"
-androidGradlePlugin = "8.10.1"
-composeMultiplatform = "1.8.0"
+kotlin = "2.2.20"
+androidGradlePlugin = "8.13.0"
+composeMultiplatform = "1.9.0"
 
 [plugins]
 kotlin-multiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
-kotlinx-binary-compatibility-validator = { id = "org.jetbrains.kotlinx.binary-compatibility-validator", version = "0.18.0" }
+kotlinx-binary-compatibility-validator = { id = "org.jetbrains.kotlinx.binary-compatibility-validator", version = "0.18.1" }
 android-library = { id = "com.android.library", version.ref = "androidGradlePlugin" }
 android-application = { id = "com.android.application", version.ref = "androidGradlePlugin" }
 compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
-paparazzi = { id = "app.cash.paparazzi", version = "2.0.0-alpha01" }
-maven-publish = { id = "com.vanniktech.maven.publish", version = "0.33.0" }
+paparazzi = { id = "app.cash.paparazzi", version = "2.0.0-alpha02" }
+maven-publish = { id = "com.vanniktech.maven.publish", version = "0.34.0" }
 
 [libraries]
-androidx-core = { module = "androidx.core:core", version = "1.16.0" }
+androidx-core = { module = "androidx.core:core", version = "1.17.0" }
 compose-multiplatform-runtime = { module = "org.jetbrains.compose.runtime:runtime", version.ref = "composeMultiplatform" }
 compose-multiplatform-foundation = { module = "org.jetbrains.compose.foundation:foundation", version.ref = "composeMultiplatform" }
 compose-multiplatform-ui-util = { module = "org.jetbrains.compose.ui:ui-util", version.ref = "composeMultiplatform" }
 
 # Sample dependencies
-kotlinx-immutable-collections = { module = "org.jetbrains.kotlinx:kotlinx-collections-immutable", version = "0.3.7" }
+kotlinx-immutable-collections = { module = "org.jetbrains.kotlinx:kotlinx-collections-immutable", version = "0.4.0" }
 compose-multiplatform-ui = { module = "org.jetbrains.compose.ui:ui", version.ref = "composeMultiplatform" }
-compose-multiplatform-material3 = { module = "org.jetbrains.compose.material3:material3", version.ref = "composeMultiplatform" }
+compose-multiplatform-material3 = { module = "org.jetbrains.compose.material3:material3", version = "1.9.0-beta06" }
 compose-material-icons-core = { module = "org.jetbrains.compose.material:material-icons-core", version = "1.7.3" }
 androidx-appcompat = { module = "androidx.appcompat:appcompat", version = "1.7.1" }
-androidx-activity-compose = { module = "androidx.activity:activity-compose", version = "1.10.1" }
-compose-android-runtime = { module = "androidx.compose.runtime:runtime", version = "1.8.0" }
-compose-android-foundation = { module = "androidx.compose.foundation:foundation", version = "1.8.0" }
-compose-android-ui = { module = "androidx.compose.ui:ui", version = "1.8.0" }
-compose-android-material3 = { module = "androidx.compose.material3:material3", version = "1.3.2" }
+androidx-activity-compose = { module = "androidx.activity:activity-compose", version = "1.11.0" }
+compose-android-runtime = { module = "androidx.compose.runtime:runtime", version = "1.9.2" }
+compose-android-foundation = { module = "androidx.compose.foundation:foundation", version = "1.9.2" }
+compose-android-ui = { module = "androidx.compose.ui:ui", version = "1.9.2" }
+compose-android-material3 = { module = "androidx.compose.material3:material3", version = "1.4.0" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/grid/api/android/grid.api
+++ b/grid/api/android/grid.api
@@ -27,6 +27,7 @@ public abstract interface class com/cheonjaeung/compose/grid/BoxGridScope {
 	public abstract fun position (Landroidx/compose/ui/Modifier;II)Landroidx/compose/ui/Modifier;
 	public abstract fun row (Landroidx/compose/ui/Modifier;I)Landroidx/compose/ui/Modifier;
 	public abstract fun span (Landroidx/compose/ui/Modifier;Lkotlin/jvm/functions/Function1;)Landroidx/compose/ui/Modifier;
+	public static synthetic fun span$default (Lcom/cheonjaeung/compose/grid/BoxGridScope;Landroidx/compose/ui/Modifier;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Landroidx/compose/ui/Modifier;
 }
 
 public final class com/cheonjaeung/compose/grid/BoxGridScope$DefaultImpls {
@@ -58,6 +59,7 @@ public final class com/cheonjaeung/compose/grid/GridKt {
 public abstract interface class com/cheonjaeung/compose/grid/GridScope {
 	public abstract fun align (Landroidx/compose/ui/Modifier;Landroidx/compose/ui/Alignment;)Landroidx/compose/ui/Modifier;
 	public abstract fun span (Landroidx/compose/ui/Modifier;Lkotlin/jvm/functions/Function1;)Landroidx/compose/ui/Modifier;
+	public static synthetic fun span$default (Lcom/cheonjaeung/compose/grid/GridScope;Landroidx/compose/ui/Modifier;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Landroidx/compose/ui/Modifier;
 }
 
 public final class com/cheonjaeung/compose/grid/GridScope$DefaultImpls {

--- a/grid/api/jvm/grid.api
+++ b/grid/api/jvm/grid.api
@@ -27,6 +27,7 @@ public abstract interface class com/cheonjaeung/compose/grid/BoxGridScope {
 	public abstract fun position (Landroidx/compose/ui/Modifier;II)Landroidx/compose/ui/Modifier;
 	public abstract fun row (Landroidx/compose/ui/Modifier;I)Landroidx/compose/ui/Modifier;
 	public abstract fun span (Landroidx/compose/ui/Modifier;Lkotlin/jvm/functions/Function1;)Landroidx/compose/ui/Modifier;
+	public static synthetic fun span$default (Lcom/cheonjaeung/compose/grid/BoxGridScope;Landroidx/compose/ui/Modifier;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Landroidx/compose/ui/Modifier;
 }
 
 public final class com/cheonjaeung/compose/grid/BoxGridScope$DefaultImpls {
@@ -58,6 +59,7 @@ public final class com/cheonjaeung/compose/grid/GridKt {
 public abstract interface class com/cheonjaeung/compose/grid/GridScope {
 	public abstract fun align (Landroidx/compose/ui/Modifier;Landroidx/compose/ui/Alignment;)Landroidx/compose/ui/Modifier;
 	public abstract fun span (Landroidx/compose/ui/Modifier;Lkotlin/jvm/functions/Function1;)Landroidx/compose/ui/Modifier;
+	public static synthetic fun span$default (Lcom/cheonjaeung/compose/grid/GridScope;Landroidx/compose/ui/Modifier;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Landroidx/compose/ui/Modifier;
 }
 
 public final class com/cheonjaeung/compose/grid/GridScope$DefaultImpls {

--- a/samples/android/build.gradle.kts
+++ b/samples/android/build.gradle.kts
@@ -6,12 +6,12 @@ plugins {
 
 android {
     namespace = "${project.group}.sample.android"
-    compileSdk = 35
+    compileSdk = 36
 
     defaultConfig {
         applicationId = "${project.group}.sample.android"
         minSdk = 21
-        targetSdk = 35
+        targetSdk = 36
         versionCode = 1
         versionName = "${project.version}"
     }

--- a/samples/shared/build.gradle.kts
+++ b/samples/shared/build.gradle.kts
@@ -53,7 +53,7 @@ kotlin {
 
 android {
     namespace = "${project.group}.sample.shared"
-    compileSdk = 35
+    compileSdk = 36
 
     sourceSets["main"].manifest.srcFile("src/androidMain/AndroidManifest.xml")
 


### PR DESCRIPTION
Library Dependencies
- Kotlin 2.1.0 -> 2.2.20
- AGP 8.10.1 -> 8.13.0
- Target SDK 35 -> 36
- Gradle 8.11.1 -> 8.13
- Compose Multiplatform 1.8.0 -> 1.9.0
- androidx.core 1.16.0 -> 1.17.0

Project Dependencies
- Kotlin Binary Compatibility Validator 1.18.0 -> 1.18.1
- Maven Publish Plugin 0.33.0 -> 0.34.0
- Paparazzi 2.0.0-alpha01 -> 2.0.0-alpha02

Sample Dependencies
- Kotlin Immutable Collections 0.3.7 -> 0.4.0
- Compose Multiplatform Material3 1.8.0 -> 1.9.0-beta06
- Compose Android 1.8.0 -> 1.9.2
- Compose android Material3 1.3.2 -> 1.4.0
- Activity Compose 1.10.1 -> 1.11.0