### PR TITLE
Optimize box grid arrangement

### DIFF
--- a/grid/src/commonMain/kotlin/com/cheonjaeung/compose/grid/BoxGridMeasurePolicy.kt
+++ b/grid/src/commonMain/kotlin/com/cheonjaeung/compose/grid/BoxGridMeasurePolicy.kt
@@ -183,6 +183,24 @@ private class BoxGridMeasureHelper(
     ): GridArrangeResult = with(measureScope) {
         val placeableCount = measureResult.placeableMeasureInfos.size
         val placeablePositionInfos = mutableListOfNulls<PlaceablePositionInfo?>(placeableCount)
+        val rowCount = cellHeightConstraintList.size
+        val columnCount = cellWidthConstraintList.size
+
+        val horizontalSpacingPx = horizontalSpacing.roundToPx()
+        val verticalSpacingPx = verticalSpacing.roundToPx()
+
+        var currentX = 0
+        var currentY = 0
+        val xPositions = IntArray(columnCount)
+        val yPositions = IntArray(rowCount)
+        for (i in 0 until columnCount) {
+            xPositions[i] = currentX
+            currentX += cellWidthConstraintList[i] + horizontalSpacingPx
+        }
+        for (i in 0 until rowCount) {
+            yPositions[i] = currentY
+            currentY += cellHeightConstraintList[i] + verticalSpacingPx
+        }
 
         measureResult.placeableMeasureInfos.fastForEachIndexed { index, placeableMeasureInfo ->
             if (placeableMeasureInfo != null) {
@@ -196,25 +214,12 @@ private class BoxGridMeasureHelper(
                     height = placeableMeasureInfo.cellConstraints.maxHeight
                 )
 
-                val xPosition = if (layoutDirection == LayoutDirection.Ltr) {
-                    val xWithoutSpacing = cellWidthConstraintList.sumOfIndexed { i, c ->
-                        if (i < columnPosition) c else 0
-                    }
-                    xWithoutSpacing + horizontalSpacing.roundToPx() * columnPosition
+                val xPosition = xPositions[if (layoutDirection == LayoutDirection.Ltr) {
+                    columnPosition
                 } else {
-                    val layoutWidth = measureResult.layoutSize.width.roundToInt()
-                    val xWithoutSpacing = layoutWidth - cellWidthConstraintList.sumOfIndexed { i, c ->
-                        if (i <= columnPosition) c else 0
-                    }
-                    xWithoutSpacing - horizontalSpacing.roundToPx() * columnPosition
-                }
-
-                val yPosition = run {
-                    val yWithoutSpacing = cellHeightConstraintList.sumOfIndexed { i, c ->
-                        if (i < rowPosition) c else 0
-                    }
-                    yWithoutSpacing + verticalSpacing.roundToPx() * rowPosition
-                }
+                    columnCount - columnPosition - 1
+                }]
+                val yPosition = yPositions[rowPosition]
 
                 val alignedOffset = alignment.align(
                     size = placeable.size(),

--- a/grid/src/commonMain/kotlin/com/cheonjaeung/compose/grid/CollectionUtils.kt
+++ b/grid/src/commonMain/kotlin/com/cheonjaeung/compose/grid/CollectionUtils.kt
@@ -31,14 +31,3 @@ internal fun IntArray.maxOrZero(): Int {
     }
     return maxValue
 }
-
-/**
- * Returns the sum of the all values produced by [selector] function applied to each element.
- */
-internal inline fun <T> Iterable<T>.sumOfIndexed(selector: (Int, T) -> Int): Int {
-    var sum = 0
-    for ((index, element) in this.withIndex()) {
-        sum += selector(index, element)
-    }
-    return sum
-}


### PR DESCRIPTION
The time complexity of previous arrangement logic was **O(N * M)** (N = rowCount, M = columnCount). The new logic improve the time complexity to **O(N + M)** using pre-calculation.

And this commit removes `sumOfIndexed` utility function because it is no more used.